### PR TITLE
setting this instance variable is not necessary

### DIFF
--- a/includes/modules/export/mpdf/class-pb-pdf.php
+++ b/includes/modules/export/mpdf/class-pb-pdf.php
@@ -12,13 +12,6 @@ use \PressBooks\Export\Export;
 class Pdf extends Export {
 
 	/**
-	 * Service URL
-	 *
-	 * @var string
-	 */
-	public $url;
-
-	/**
 	 * Fullpath to book CSS file.
 	 *
 	 * @var string
@@ -63,12 +56,6 @@ class Pdf extends Export {
 		$this->options = get_option( 'pressbooks_theme_options_mpdf' );
 
 		$this->exportStylePath = $this->getExportStylePath( 'mpdf' );
-
-		// Set the access protected "format/xhtml" URL with a valid timestamp and NONCE
-		// @todo is this necessary?
-		$timestamp = time();
-		$md5 = $this->nonce( $timestamp );
-		$this->url = home_url() . "/format/xhtml?timestamp={$timestamp}&hashkey={$md5}";
 
 		$this->themeOptionsOverrides();
 	}


### PR DESCRIPTION
PrinceXML output uses this `format/xhtml` redirect to generate one long xhtml file which it then uses for its conversion process. mPDF doesn't need this. 
